### PR TITLE
Generate installable artifact

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,45 +7,57 @@ app:
   - BITRISE_SCHEME: iOS Demo
   - BITRISE_DISTRIBUTION_METHOD: development
 workflows:
-  primary:
+  _setup:
+    description: |
+      This is a utility workflow for common tasks used by other workflows
+    steps:
+    - git-clone@8: {}
+    - cache-pull@2: {}
+    - recreate-user-schemes@1:
+        inputs:
+        - project_path: $BITRISE_PROJECT_PATH
+  test:
     description: |
       The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
 
       Next steps:
       - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
     steps:
-    - git-clone@8: {}
-    - cache-pull@2: {}
-    - recreate-user-schemes@1:
-        inputs:
-        - project_path: $BITRISE_PROJECT_PATH
     - xcode-test@4:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
         - scheme: $BITRISE_SCHEME
         - test_repetition_mode: retry_on_failure
+    - deploy-to-bitrise-io@2: {}
+  primary:
+    before_run:
+    - _setup
+    - test
+    description: |
+      This workflow tests, builds and deploys the debug version of the app as well as the generated test report using *Deploy to bitrise.io* Step.
+
+      For testing the *retry_on_failure* test repetition mode is enabled.
+    steps:
+    - xcode-build-for-simulator@0:
+        inputs:
+        - project_path: $BITRISE_PROJECT_PATH
+        - scheme: $BITRISE_SCHEME
+        - configuration: Debug
     - cache-push@2: {}
     - deploy-to-bitrise-io@2: {}
   deploy:
     description: |
-      The workflow tests, builds and deploys the app using *Deploy to bitrise.io* step.
+      This workflow tests, builds, and deploys the release version of the app.
 
-      For testing the *retry_on_failure* test repetition mode is enabled.
+      In order for this workflow to run successfully you will need to complete setting up code-signing.
 
       Next steps:
       - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
       - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
+    before_run:
+    - _setup
+    - test
     steps:
-    - git-clone@8: {}
-    - cache-pull@2: {}
-    - recreate-user-schemes@1:
-        inputs:
-        - project_path: $BITRISE_PROJECT_PATH
-    - xcode-test@4:
-        inputs:
-        - project_path: $BITRISE_PROJECT_PATH
-        - scheme: $BITRISE_SCHEME
-        - test_repetition_mode: retry_on_failure
     - xcode-archive@4:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -62,7 +62,7 @@ workflows:
             set -e
             # debug log
             set -x
-            # zip the app bundle
+            # zip the app package
             cd $BITRISE_DEPLOY_DIR
             zip -r iOS\ Demo.app.zip iOS\ Demo.app
     - deploy-to-bitrise-io@2: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,7 +54,7 @@ workflows:
             set -x
             # zip the app bundle
             cd $BITRISE_DEPLOY_DIR
-            zip iOS\ Demo.app.zip iOS\ Demo.app
+            zip -r iOS\ Demo.app.zip iOS\ Demo.app
     - deploy-to-bitrise-io@2: {}
   deploy:
     description: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,9 +3,9 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
 trigger_map:
 - push_branch: '*'
-  workflow: test-pr
+  workflow: primary
 - pull_request_source_branch: '*'
-  workflow: test-pr
+  workflow: primary
 app:
   envs:
   - BITRISE_PROJECT_PATH: iOS Demo.xcodeproj
@@ -35,12 +35,12 @@ workflows:
         - project_path: $BITRISE_PROJECT_PATH
         - scheme: $BITRISE_SCHEME
         - test_repetition_mode: retry_on_failure
-  test-pr:
+  primary:
     before_run:
     - _test
     steps:
     - deploy-to-bitrise-io@2: {}
-  primary:
+  deploy-debug:
     description: |-
       This workflow tests, builds and deploys the debug version of the app for iOS simulator as well as the generated test report using *Deploy to bitrise.io* Step.
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,9 +3,9 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
 trigger_map:
 - push_branch: '*'
-  workflow: primary
+  workflow: test-pr
 - pull_request_source_branch: '*'
-  workflow: primary
+  workflow: test-pr
 app:
   envs:
   - BITRISE_PROJECT_PATH: iOS Demo.xcodeproj
@@ -21,27 +21,32 @@ workflows:
     - recreate-user-schemes@1:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
-  test:
+  _test:
     description: |-
-      The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
+      This workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
 
       Next steps:
       - Check out [Getting started with iOS apps](https://devcenter.bitrise.io/en/getting-started/getting-started-with-ios-apps.html).
+    before_run:
+      - _setup
     steps:
     - xcode-test@4:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
         - scheme: $BITRISE_SCHEME
         - test_repetition_mode: retry_on_failure
+  test-pr:
+    before_run:
+    - _test
+    steps:
     - deploy-to-bitrise-io@2: {}
   primary:
-    before_run:
-    - _setup
-    - test
     description: |-
       This workflow tests, builds and deploys the debug version of the app as well as the generated test report using *Deploy to bitrise.io* Step.
 
       For testing the *retry_on_failure* test repetition mode is enabled.
+    before_run:
+    - _test
     steps:
     - xcode-build-for-simulator@0:
         inputs:
@@ -71,8 +76,7 @@ workflows:
       - Set up [Connecting to an Apple service with API key](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html##).
       - Or further customise code signing following our [iOS code signing](https://devcenter.bitrise.io/en/code-signing/ios-code-signing.html) guide.
     before_run:
-    - _setup
-    - test
+    - _test
     steps:
     - xcode-archive@4:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,6 +1,11 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
+trigger_map:
+- push_branch: '*'
+  workflow: primary
+- pull_request_source_branch: '*'
+  workflow: primary
 app:
   envs:
   - BITRISE_PROJECT_PATH: iOS Demo.xcodeproj

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ app:
   - BITRISE_DISTRIBUTION_METHOD: development
 workflows:
   _setup:
-    description: |
+    description: |-
       This is a utility workflow for common tasks used by other workflows
     steps:
     - git-clone@8: {}
@@ -17,7 +17,7 @@ workflows:
         inputs:
         - project_path: $BITRISE_PROJECT_PATH
   test:
-    description: |
+    description: |-
       The workflow executes the tests. The *retry_on_failure* test repetition mode is enabled.
 
       Next steps:
@@ -33,7 +33,7 @@ workflows:
     before_run:
     - _setup
     - test
-    description: |
+    description: |-
       This workflow tests, builds and deploys the debug version of the app as well as the generated test report using *Deploy to bitrise.io* Step.
 
       For testing the *retry_on_failure* test repetition mode is enabled.
@@ -44,9 +44,20 @@ workflows:
         - scheme: $BITRISE_SCHEME
         - configuration: Debug
     - cache-push@2: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+            # zip the app bundle
+            cd $BITRISE_DEPLOY_DIR
+            zip iOS\ Demo.app.zip iOS\ Demo.app
     - deploy-to-bitrise-io@2: {}
   deploy:
-    description: |
+    description: |-
       This workflow tests, builds, and deploys the release version of the app.
 
       In order for this workflow to run successfully you will need to complete setting up code-signing.

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -42,7 +42,7 @@ workflows:
     - deploy-to-bitrise-io@2: {}
   primary:
     description: |-
-      This workflow tests, builds and deploys the debug version of the app as well as the generated test report using *Deploy to bitrise.io* Step.
+      This workflow tests, builds and deploys the debug version of the app for iOS simulator as well as the generated test report using *Deploy to bitrise.io* Step.
 
       For testing the *retry_on_failure* test repetition mode is enabled.
     before_run:

--- a/iOS Demo.xcodeproj/project.pbxproj
+++ b/iOS Demo.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -462,6 +463,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS Demo.xcodeproj/project.pbxproj
+++ b/iOS Demo.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.iOS-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Context
[PLG-1349] We want demo app builds to generate artifacts of the executable apps for installation on mobile devices as well as export test reports.

## Changes
* Introduced `_setup` and `test` utility workflows in order to reduce repeated steps across workflows
* Made `primary` workflow use new `_test` utility workflow and deploy
* Modified `deploy` workflow to utilize the new `_test` utility workflow and generate a release app package
* Added `deploy-demo` to run tests and generate a debug simulator app package
* Added a trigger map to kick off primary workflow

## Decisions
* Decided to build the simulator app package for all architectures so users don't have to bother switching to the Intel stack if they want to run the app on an Intel simulator
* Zipped the simulator app package in a separate script step as `.app` "files" are actually directories and the deploy step will skip over directories
* Kept a separate `_test` workflow in order to prevent deploying twice in `primary` and `deploy` workflows (once would be for test and a second time for the app artifact)
  * `deploy-demo`, `primary`, and `deploy` all execute the `_test` workflow then later have a deploy step

[PLG-1349]: https://bitrise.atlassian.net/browse/PLG-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ